### PR TITLE
Fix timer cleanup

### DIFF
--- a/src/languageservice/serverStatus.ts
+++ b/src/languageservice/serverStatus.ts
@@ -42,6 +42,7 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
     private _statusBarItem: vscode.StatusBarItem = undefined;
     private _onDidChangeActiveTextEditorEvent: vscode.Disposable;
     private _onDidCloseTextDocument: vscode.Disposable;
+    private _progressTimerId: NodeJS.Timeout | undefined;
 
     constructor() {
         this._statusBarItem = vscode.window.createStatusBarItem(
@@ -72,6 +73,10 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
 
     public serviceInstalled(): void {
         this._statusBarItem.command = undefined;
+        if (this._progressTimerId) {
+            clearInterval(this._progressTimerId);
+            this._progressTimerId = undefined;
+        }
         this._statusBarItem.text = Constants.serviceInstalled;
         this._statusBarItem.show();
         // Cleat the status bar after 2 seconds
@@ -82,6 +87,10 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
 
     public serviceInstallationFailed(): void {
         this._statusBarItem.command = undefined;
+        if (this._progressTimerId) {
+            clearInterval(this._progressTimerId);
+            this._progressTimerId = undefined;
+        }
         this._statusBarItem.text = Constants.serviceInstallationFailed;
         this._statusBarItem.show();
     }
@@ -90,7 +99,7 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
         let index = 0;
         let progressTicks = ["|", "/", "-", "\\"];
 
-        setInterval(() => {
+        this._progressTimerId = setInterval(() => {
             index++;
             if (index > 3) {
                 index = 0;
@@ -105,6 +114,10 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
     }
 
     dispose(): void {
+        if (this._progressTimerId) {
+            clearInterval(this._progressTimerId);
+            this._progressTimerId = undefined;
+        }
         this.destroyStatusBar();
         this._onDidChangeActiveTextEditorEvent.dispose();
         this._onDidCloseTextDocument.dispose();
@@ -129,6 +142,10 @@ export class ServerStatusView implements IStatusView, vscode.Disposable {
     private destroyStatusBar(): void {
         if (typeof this._statusBarItem !== "undefined") {
             this._statusBarItem.dispose();
+        }
+        if (this._progressTimerId) {
+            clearInterval(this._progressTimerId);
+            this._progressTimerId = undefined;
         }
     }
 


### PR DESCRIPTION
### 🛠️ Fix: Clear Server Progress Timer After Install

**Problem:**  
The `ServerStatusView` sets a recurring `setInterval` timer in `showProgress()` to animate the status bar during service installation. However, the timer was not being cleared after installation completed, causing the callback to continue firing every 200ms indefinitely — even after the status bar was hidden. This results in unnecessary background activity and potential resource leaks, particularly in long-running sessions.

**Fix:**  
Store the `setInterval` handle in `_progressTimerId`, and clear it:
- When the service installs successfully
- When installation fails
- When the view is disposed

This ensures the interval timer is always stopped cleanly when it’s no longer needed.

**Impact:**  
- Prevents unnecessary event execution post-install
- Reduces background CPU activity and memory churn
- No change to visible behavior or install flow
- Minor reliability and performance win

> _Initial bug identification assisted by OpenAI Codex._
